### PR TITLE
하드 코딩되어 있는 값을 제거. 해당 값을 application.properties 에 있는 값으로 주입할 수 있도록 코드 변경.

### DIFF
--- a/openbookmarks_be/src/main/java/com/example/openbookmarks_be/config/SQLiteConfig.java
+++ b/openbookmarks_be/src/main/java/com/example/openbookmarks_be/config/SQLiteConfig.java
@@ -9,11 +9,17 @@ import javax.sql.DataSource;
 @Configuration
 public class SQLiteConfig {
 
+    @Value("${spring.datasource.url}")
+    private String dbUrl;
+
+    @Value("${spring.datasource.driver-class-name}")
+    private String dbDriverClassName;
+
     @Bean
     public DataSource dataSource() {
         return DataSourceBuilder.create()
-                .url("jdbc:sqlite:bookmarks.db")
-                .driverClassName("org.sqlite.JDBC")
+                .url(dbUrl)
+                .driverClassName(dbDriverClassName)
                 .build();
     }
 }

--- a/openbookmarks_be/src/main/java/com/example/openbookmarks_be/config/SQLiteConfig.java
+++ b/openbookmarks_be/src/main/java/com/example/openbookmarks_be/config/SQLiteConfig.java
@@ -1,10 +1,10 @@
 package com.example.openbookmarks_be.config;
 
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.boot.jdbc.DataSourceBuilder;
-
-import javax.sql.DataSource;
 
 @Configuration
 public class SQLiteConfig {


### PR DESCRIPTION
### 수정한 내용
closes : #14 

중복된 DB 관련 설정에서 하드 코딩된 값을 지우고, `@Value` 애노테이션을 이용하여 `application.properties` 의 값을 이용할 수 있도록 수정했습니다.

중복된 부분 중 하드 코딩된 값을 지운 이유는 다음과 같습니다.
- 차후 실제 배포 단계에서 값 변경 시, 깃허브를 통한 실제 값 유출 가능성 존재
- 데이타베이스 저장소 설정이 바뀌어도 유연하게 바뀔 수 있도록 변수화를 고려

의견 남겨주시면 감사하겠습니다.