### PR TITLE
hotfix: LinkCard UI 링크 렌더링 버그

### DIFF
--- a/Open-Bookmarks-front/src/components/LinkCard.js
+++ b/Open-Bookmarks-front/src/components/LinkCard.js
@@ -1,18 +1,18 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import { toggleLike, incrementView } from '../services/api';
+import React from "react";
+import { Link } from "react-router-dom";
+import { toggleLike, incrementView } from "../services/api";
 
 const LinkCard = ({ link, category, currentUser }) => {
   const handleLike = async () => {
     if (!currentUser) {
-      alert('로그인 후 좋아요를 누를 수 있습니다.');
+      alert("로그인 후 좋아요를 누를 수 있습니다.");
       return;
     }
     try {
       await toggleLike(link.id);
       // 백엔드에서 업데이트된 링크 상태를 반영하도록 상위 컴포넌트에서 리프레시
     } catch (err) {
-      alert('좋아요 처리에 실패했습니다.');
+      alert("좋아요 처리에 실패했습니다.");
     }
   };
 
@@ -20,7 +20,7 @@ const LinkCard = ({ link, category, currentUser }) => {
     try {
       await incrementView(link.id);
     } catch (err) {
-      console.error('조회수 증가 실패:', err);
+      console.error("조회수 증가 실패:", err);
     }
   };
 
@@ -36,7 +36,7 @@ const LinkCard = ({ link, category, currentUser }) => {
         href={link.url}
         target="_blank"
         rel="noopener noreferrer"
-        className="text-blue-600 hover:underline mb-2"
+        className="text-blue-600 hover:underline mb-2 break-words max-w-full overflow-hidden"
         onClick={handleView}
       >
         {link.url}
@@ -49,7 +49,7 @@ const LinkCard = ({ link, category, currentUser }) => {
         >
           <svg
             className="w-5 h-5 mr-1"
-            fill={'currentColor'}
+            fill={"currentColor"}
             stroke="currentColor"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "OpenBookmarks",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
# LinkCard UI 링크 렌더링 버그
## 문제 상황
![스크린샷 2025-06-09 015027](https://github.com/user-attachments/assets/a56eb564-8155-42cd-8d5f-49966cd1e14c)
`link.url`의 문자열이 공백 없이 너무 긴 경우 부모 div 박스 너비를 넘어서 보여지는 문제가 있습니다. 이러한 문제는 긴 URL이나 연속된 문자열은 줄바꿈이 되지 않기 때문에 나타납니다.

## 해결 방법
현재 프로젝트에 구현되어있는 스타일링 라이브러리는 TailWindCSS입니다. 따라서 줄 바꿈을 강제하는 Tailwind 유틸리티 클래스를 추가합니다.
`LinkCard` 컴포넌트의 `a`태그 스타일에 다음과 같은 속성을 추가합니다.
```
break-words max-w-full overflow-hidden
```
위 세가지 유틸리티 클래스는 다음과 같은 동작을 정의합니다.
`break-words`: 단어(혹은 URL)가 너무 길면 단어 중간에서 줄바꿈 허용
`max-w-full`: 부모 박스 너비를 넘지 않게 제한
`overflow-hidden`: 혹시 넘친 내용이 있어도 잘라냄

overflow-hidden는 추후 UI 스타일을 건드리는 코드가 추가되어 문자열 줄바꿈이 되지 않는 경우가 생기더라도 링크가 박스 바깥에 렌더링 되는 것을 막기 위한 방어적 코딩입니다. 필수는 아니므로 PR Merge때 삭제하셔도 됩니다.

## 수정 후 결과
![스크린샷 2025-06-09 015112](https://github.com/user-attachments/assets/7981b82e-bc88-4c60-b554-685807e51a65)
부모 div 박스 너비에 바운딩 되어 링크 텍스트가 더이상 밖으로 넘어가지 않아 더 깔끔하게 UI가 렌더링됩니다.