### PR TITLE
서비스 계층에서 트랜잭션 처리 추가

### DIFF
--- a/openbookmarks_be/src/main/java/com/example/openbookmarks_be/service/LinkService.java
+++ b/openbookmarks_be/src/main/java/com/example/openbookmarks_be/service/LinkService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +30,7 @@ public class LinkService {
 //        linkRepository.save(link);
 //    }
 
+    @Transactional
     public void createLink(LinkRequestDto dto, Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
@@ -36,6 +38,7 @@ public class LinkService {
         linkRepository.save(link);
     }
 
+    @Transactional(readOnly = true)
     public Page<LinkResponseDto> getLinks(String category, String search, String likedBy, Pageable pageable) {
 
         Page<Link> linksPage = category != null && !category.equals("좋아요")
@@ -43,15 +46,14 @@ public class LinkService {
                 : linkRepository.findAll(pageable);
 
         log.info("Links count: {}", linksPage.getTotalElements());
-        
+
         List<LinkResponseDto> dtos = linksPage.getContent().stream()
                 .map(LinkResponseDto::of)
                 .collect(Collectors.toList());
         return new PageImpl<>(dtos, pageable, linksPage.getTotalElements());
     }
 
-
-    // LinkService.java
+    @Transactional(readOnly = true)
     public List<LinkResponseDto> findLinksByPartialTitle(String title) {
         return linkRepository.findAllByTitleContainingIgnoreCase(title)
                 .stream()
@@ -59,7 +61,7 @@ public class LinkService {
                 .collect(Collectors.toList());
     }
 
-
+    @Transactional(readOnly = true)
     public List<LinkResponseDto> findLinksByUsername(String username) {
         List<Link> links = linkRepository.findByUser_Username(username);
         return links.stream()
@@ -67,7 +69,7 @@ public class LinkService {
                 .toList();
     }
 
-
+    @Transactional
     public boolean deleteLink(Long linkId, String username) {
         Optional<Link> optionalLink = linkRepository.findById(linkId);
         if (optionalLink.isEmpty()) {
@@ -83,7 +85,7 @@ public class LinkService {
         return true;
     }
 
-
+    @Transactional
     public boolean updateLink(Long linkId, LinkRequestDto dto, String username) {
         Optional<Link> optionalLink = linkRepository.findById(linkId);
         if (optionalLink.isEmpty()) {

--- a/openbookmarks_be/src/main/java/com/example/openbookmarks_be/service/UserService.java
+++ b/openbookmarks_be/src/main/java/com/example/openbookmarks_be/service/UserService.java
@@ -1,13 +1,12 @@
 package com.example.openbookmarks_be.service;
 
-import com.example.openbookmarks_be.dto.request.UserRequestDto;
 import com.example.openbookmarks_be.domain.User;
+import com.example.openbookmarks_be.dto.request.UserRequestDto;
 import com.example.openbookmarks_be.repository.UserRepository;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
@@ -16,11 +15,11 @@ public class UserService {
 
     private final UserRepository userRepository;
 
+    @Transactional
     public void register(UserRequestDto dto) {
         if (userRepository.findByUsername(dto.getUsername()).isPresent()) {
             throw new IllegalArgumentException("이미 존재하는 사용자입니다.");
         }
-
 
         User user = new User(dto.getUsername(), dto.getPassword());
         userRepository.save(user);


### PR DESCRIPTION
closes : #26 

## 작업 내용

#26 에서 언급한 것처럼 @Transactional 애노테이션을 추가하는 방식으로 트랜잭션 처리를 할 수 있게 하였습니다. 다만 성능 문제로 인해 클래스 단위로 처리하지 않고 메서드 단위로 처리를 하였습니다. 때문에 읽기만 하는 메서드의 경우에는 `@Transactional(readOnly = true)`를 사용하였고, 그 외에는 `@Transactional`를 사용하였습니다.

- 추가 의견 있으시면 언제든지 `commnet` 부탁드립니다.

감사합니다