### PR TITLE
커스텀 훅으로 UI 로직 통합

### DIFF
--- a/Open-Bookmarks-front/src/components/desktop/LinkDetailPage.js
+++ b/Open-Bookmarks-front/src/components/desktop/LinkDetailPage.js
@@ -1,181 +1,107 @@
-import React, { useState, useEffect } from "react";
-import { useParams, Link } from "react-router-dom";
-import {
-  getComments,
-  addComment,
-  incrementView,
-  toggleLike,
-} from "../../services/api";
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { getLinkById, getComments, addComment, toggleLike } from '../../services/api';
 
-const LinkDetailPage = ({ links, currentUser }) => {
-  const { linkId } = useParams();
-  const [link, setLink] = useState(null);
-  const [comments, setComments] = useState([]);
-  const [commentText, setCommentText] = useState("");
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+function DesktopLinkDetailPage() {
+    const { linkId } = useParams();
+    const [link, setLink] = useState(null);
+    const [comments, setComments] = useState([]);
+    const [newComment, setNewComment] = useState('');
 
-  const category = Object.keys(links).find((cat) =>
-    links[cat].some((l) => l.id === linkId)
-  );
+    useEffect(() => {
+        const fetchLinkAndComments = async () => {
+            try {
+                const linkData = await getLinkById(linkId);
+                setLink(linkData.data);
+                const commentsData = await getComments(linkId);
+                setComments(commentsData.data);
+            } catch (error) {
+                console.error("Error fetching link and comments", error);
+            }
+        };
+        fetchLinkAndComments();
+    }, [linkId]);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        // 링크는 App.js에서 제공된 links 사용
-        const foundLink = Object.values(links)
-          .flat()
-          .find((l) => l.id === linkId);
-        if (!foundLink) throw new Error("링크를 찾을 수 없습니다.");
-        setLink(foundLink);
-
-        // 조회수 증가
-        await incrementView(linkId);
-
-        // 댓글 가져오기
-        const commentResponse = await getComments(linkId);
-        setComments(commentResponse.data || []);
-        setLoading(false);
-      } catch (err) {
-        setError(err.message || "데이터를 불러오는데 실패했습니다.");
-        setLoading(false);
-      }
+    const handleAddComment = async (e) => {
+        e.preventDefault();
+        try {
+            const res = await addComment(linkId, { content: newComment });
+            setComments([...comments, res.data]);
+            setNewComment('');
+        } catch (error) {
+            console.error("Error adding comment", error);
+        }
     };
-    fetchData();
-  }, [linkId, links]);
 
-  const handleLike = async () => {
-    if (!currentUser) {
-      alert("로그인 후 좋아요를 누를 수 있습니다.");
-      return;
-    }
-    try {
-      await toggleLike(linkId);
-      // 백엔드에서 업데이트된 링크 상태를 반영하도록 리프레시
-    } catch (err) {
-      alert("좋아요 처리에 실패했습니다.");
-    }
-  };
+    const handleLike = async () => {
+        try {
+            const res = await toggleLike(linkId);
+            setLink(res.data);
+        } catch (error) {
+            console.error("Error toggling like", error);
+        }
+    };
 
-  const handleCommentSubmit = async (e) => {
-    e.preventDefault();
-    if (!currentUser) {
-      alert("로그인 후 댓글을 작성할 수 있습니다.");
-      return;
+    if (!link) {
+        return <div className="p-8 text-center text-lg">Loading...</div>;
     }
-    if (commentText.trim()) {
-      try {
-        await addComment({ linkId, text: commentText });
-        setCommentText("");
-        const commentResponse = await getComments(linkId);
-        setComments(commentResponse.data || []);
-      } catch (err) {
-        alert("댓글 작성에 실패했습니다.");
-      }
-    }
-  };
 
-  if (loading) return <div className="text-center p-4">로딩 중...</div>;
-  if (error) return <div className="text-center p-4 text-red-600">{error}</div>;
-  if (!link)
     return (
-      <div className="text-center text-gray-600">링크를 찾을 수 없습니다.</div>
-    );
-
-  return (
-    <div className="max-w-3xl mx-auto">
-      <Link
-        to={`/category/${category}`}
-        className="text-blue-600 hover:underline mb-4 inline-block"
-      >
-        ← {category}로 돌아가기
-      </Link>
-      <div className="bg-white p-6 rounded-lg shadow-md">
-        <h1 className="text-2xl font-bold text-gray-900 mb-4">{link.title}</h1>
-        <a
-          href={link.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-blue-600 hover:underline"
-        >
-          {link.url}
-        </a>
-        <p className="text-gray-600 mt-2 mb-4">{link.description}</p>
-        <div className="flex items-center justify-between mb-4">
-          <button
-            onClick={handleLike}
-            className="flex items-center text-red-500 hover:text-red-600"
-          >
-            <svg
-              className="w-5 h-5 mr-1"
-              fill={
-                link.likedBy.includes(currentUser) ? "currentColor" : "none"
-              }
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
-              />
-            </svg>
-            {link.likes}
-          </button>
-          <span className="text-gray-500">조회수: {link.views}</span>
-        </div>
-      </div>
-      <div className="mt-8">
-        <h2 className="text-xl font-bold text-gray-900 mb-4">댓글</h2>
-        {currentUser ? (
-          <form onSubmit={handleCommentSubmit} className="mb-4">
-            <textarea
-              placeholder="댓글을 입력하세요..."
-              value={commentText}
-              onChange={(e) => setCommentText(e.target.value)}
-              className="w-full p-2 border rounded mb-2"
-              rows="4"
-            ></textarea>
-            <button
-              type="submit"
-              className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
-            >
-              댓글 작성
-            </button>
-          </form>
-        ) : (
-          <p className="text-gray-600 mb-4">
-            댓글을 작성하려면{" "}
-            <Link to="/login" className="text-blue-600 hover:underline">
-              로그인
-            </Link>
-            하세요.
-          </p>
-        )}
-        <div className="space-y-4">
-          {comments.length > 0 ? (
-            comments.map((comment) => (
-              <div key={comment.id} className="bg-gray-100 p-4 rounded-lg">
-                <div className="flex justify-between items-center mb-2">
-                  <span className="font-semibold text-gray-800">
-                    {comment.user}
-                  </span>
-                  <span className="text-gray-500 text-sm">
-                    {new Date(comment.createdAt).toLocaleString()}
-                  </span>
+        <div className="container mx-auto p-8">
+            <div className="bg-white shadow-md rounded-lg p-6">
+                <h1 className="text-3xl font-bold mb-4">{link.title}</h1>
+                <p className="text-gray-600 mb-4">{link.description}</p>
+                <a
+                    href={link.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-500 hover:underline break-all"
+                >
+                    {link.url}
+                </a>
+                <div className="flex items-center text-gray-500 mt-4">
+                    <span>Views: {link.viewCount}</span>
+                    <button
+                        onClick={handleLike}
+                        className="ml-4 px-3 py-1 border border-blue-500 text-blue-500 rounded hover:bg-blue-500 hover:text-white transition"
+                    >
+                        Like ({link.likeCount})
+                    </button>
                 </div>
-                <p className="text-gray-600">{comment.text}</p>
-              </div>
-            ))
-          ) : (
-            <p className="text-gray-600">아직 댓글이 없습니다.</p>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-};
+            </div>
 
-export default LinkDetailPage;
+            <div className="mt-8">
+                <h2 className="text-2xl font-bold mb-4">Comments</h2>
+                <form onSubmit={handleAddComment} className="bg-white shadow-md rounded-lg p-6 mb-6">
+                    <textarea
+                        className="w-full p-2 border rounded"
+                        rows="3"
+                        placeholder="Add a comment..."
+                        value={newComment}
+                        onChange={(e) => setNewComment(e.target.value)}
+                    ></textarea>
+                    <button
+                        type="submit"
+                        className="mt-2 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+                    >
+                        Submit Comment
+                    </button>
+                </form>
+
+                <div className="space-y-4">
+                    {comments.length > 0 ? (
+                        comments.map((comment) => (
+                            <div key={comment.id} className="bg-white shadow-md rounded-lg p-4">
+                                <p>{comment.content}</p>
+                            </div>
+                        ))
+                    ) : (
+                        <p>No comments yet.</p>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default DesktopLinkDetailPage;

--- a/Open-Bookmarks-front/src/components/desktop/LinkDetailPage.js.bak
+++ b/Open-Bookmarks-front/src/components/desktop/LinkDetailPage.js.bak
@@ -1,0 +1,181 @@
+import React, { useState, useEffect } from "react";
+import { useParams, Link } from "react-router-dom";
+import {
+  getComments,
+  addComment,
+  incrementView,
+  toggleLike,
+} from "../../services/api";
+
+const LinkDetailPage = ({ links, currentUser }) => {
+  const { linkId } = useParams();
+  const [link, setLink] = useState(null);
+  const [comments, setComments] = useState([]);
+  const [commentText, setCommentText] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const category = Object.keys(links).find((cat) =>
+    links[cat].some((l) => l.id === linkId)
+  );
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        // 링크는 App.js에서 제공된 links 사용
+        const foundLink = Object.values(links)
+          .flat()
+          .find((l) => l.id === linkId);
+        if (!foundLink) throw new Error("링크를 찾을 수 없습니다.");
+        setLink(foundLink);
+
+        // 조회수 증가
+        await incrementView(linkId);
+
+        // 댓글 가져오기
+        const commentResponse = await getComments(linkId);
+        setComments(commentResponse.data || []);
+        setLoading(false);
+      } catch (err) {
+        setError(err.message || "데이터를 불러오는데 실패했습니다.");
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [linkId, links]);
+
+  const handleLike = async () => {
+    if (!currentUser) {
+      alert("로그인 후 좋아요를 누를 수 있습니다.");
+      return;
+    }
+    try {
+      await toggleLike(linkId);
+      // 백엔드에서 업데이트된 링크 상태를 반영하도록 리프레시
+    } catch (err) {
+      alert("좋아요 처리에 실패했습니다.");
+    }
+  };
+
+  const handleCommentSubmit = async (e) => {
+    e.preventDefault();
+    if (!currentUser) {
+      alert("로그인 후 댓글을 작성할 수 있습니다.");
+      return;
+    }
+    if (commentText.trim()) {
+      try {
+        await addComment({ linkId, text: commentText });
+        setCommentText("");
+        const commentResponse = await getComments(linkId);
+        setComments(commentResponse.data || []);
+      } catch (err) {
+        alert("댓글 작성에 실패했습니다.");
+      }
+    }
+  };
+
+  if (loading) return <div className="text-center p-4">로딩 중...</div>;
+  if (error) return <div className="text-center p-4 text-red-600">{error}</div>;
+  if (!link)
+    return (
+      <div className="text-center text-gray-600">링크를 찾을 수 없습니다.</div>
+    );
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <Link
+        to={`/category/${category}`}
+        className="text-blue-600 hover:underline mb-4 inline-block"
+      >
+        ← {category}로 돌아가기
+      </Link>
+      <div className="bg-white p-6 rounded-lg shadow-md">
+        <h1 className="text-2xl font-bold text-gray-900 mb-4">{link.title}</h1>
+        <a
+          href={link.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 hover:underline"
+        >
+          {link.url}
+        </a>
+        <p className="text-gray-600 mt-2 mb-4">{link.description}</p>
+        <div className="flex items-center justify-between mb-4">
+          <button
+            onClick={handleLike}
+            className="flex items-center text-red-500 hover:text-red-600"
+          >
+            <svg
+              className="w-5 h-5 mr-1"
+              fill={
+                link.likedBy.includes(currentUser) ? "currentColor" : "none"
+              }
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+              />
+            </svg>
+            {link.likes}
+          </button>
+          <span className="text-gray-500">조회수: {link.views}</span>
+        </div>
+      </div>
+      <div className="mt-8">
+        <h2 className="text-xl font-bold text-gray-900 mb-4">댓글</h2>
+        {currentUser ? (
+          <form onSubmit={handleCommentSubmit} className="mb-4">
+            <textarea
+              placeholder="댓글을 입력하세요..."
+              value={commentText}
+              onChange={(e) => setCommentText(e.target.value)}
+              className="w-full p-2 border rounded mb-2"
+              rows="4"
+            ></textarea>
+            <button
+              type="submit"
+              className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+            >
+              댓글 작성
+            </button>
+          </form>
+        ) : (
+          <p className="text-gray-600 mb-4">
+            댓글을 작성하려면{" "}
+            <Link to="/login" className="text-blue-600 hover:underline">
+              로그인
+            </Link>
+            하세요.
+          </p>
+        )}
+        <div className="space-y-4">
+          {comments.length > 0 ? (
+            comments.map((comment) => (
+              <div key={comment.id} className="bg-gray-100 p-4 rounded-lg">
+                <div className="flex justify-between items-center mb-2">
+                  <span className="font-semibold text-gray-800">
+                    {comment.user}
+                  </span>
+                  <span className="text-gray-500 text-sm">
+                    {new Date(comment.createdAt).toLocaleString()}
+                  </span>
+                </div>
+                <p className="text-gray-600">{comment.text}</p>
+              </div>
+            ))
+          ) : (
+            <p className="text-gray-600">아직 댓글이 없습니다.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LinkDetailPage;

--- a/Open-Bookmarks-front/src/components/mobile/LinkDetailPage.js
+++ b/Open-Bookmarks-front/src/components/mobile/LinkDetailPage.js
@@ -1,181 +1,107 @@
-import React, { useState, useEffect } from "react";
-import { useParams, Link } from "react-router-dom";
-import {
-  getComments,
-  addComment,
-  incrementView,
-  toggleLike,
-} from "../../services/api";
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { getLinkById, getComments, addComment, toggleLike } from '../../services/api';
 
-const LinkDetailPage = ({ links, currentUser }) => {
-  const { linkId } = useParams();
-  const [link, setLink] = useState(null);
-  const [comments, setComments] = useState([]);
-  const [commentText, setCommentText] = useState("");
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+function MobileLinkDetailPage() {
+    const { linkId } = useParams();
+    const [link, setLink] = useState(null);
+    const [comments, setComments] = useState([]);
+    const [newComment, setNewComment] = useState('');
 
-  const category = Object.keys(links).find((cat) =>
-    links[cat].some((l) => l.id === linkId)
-  );
+    useEffect(() => {
+        const fetchLinkAndComments = async () => {
+            try {
+                const linkData = await getLinkById(linkId);
+                setLink(linkData.data);
+                const commentsData = await getComments(linkId);
+                setComments(commentsData.data);
+            } catch (error) {
+                console.error("Error fetching link and comments", error);
+            }
+        };
+        fetchLinkAndComments();
+    }, [linkId]);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        // 링크는 App.js에서 제공된 links 사용
-        const foundLink = Object.values(links)
-          .flat()
-          .find((l) => l.id === linkId);
-        if (!foundLink) throw new Error("링크를 찾을 수 없습니다.");
-        setLink(foundLink);
-
-        // 조회수 증가
-        await incrementView(linkId);
-
-        // 댓글 가져오기
-        const commentResponse = await getComments(linkId);
-        setComments(commentResponse.data || []);
-        setLoading(false);
-      } catch (err) {
-        setError(err.message || "데이터를 불러오는데 실패했습니다.");
-        setLoading(false);
-      }
+    const handleAddComment = async (e) => {
+        e.preventDefault();
+        try {
+            const res = await addComment(linkId, { content: newComment });
+            setComments([...comments, res.data]);
+            setNewComment('');
+        } catch (error) {
+            console.error("Error adding comment", error);
+        }
     };
-    fetchData();
-  }, [linkId, links]);
 
-  const handleLike = async () => {
-    if (!currentUser) {
-      alert("로그인 후 좋아요를 누를 수 있습니다.");
-      return;
-    }
-    try {
-      await toggleLike(linkId);
-      // 백엔드에서 업데이트된 링크 상태를 반영하도록 리프레시
-    } catch (err) {
-      alert("좋아요 처리에 실패했습니다.");
-    }
-  };
+    const handleLike = async () => {
+        try {
+            const res = await toggleLike(linkId);
+            setLink(res.data);
+        } catch (error) {
+            console.error("Error toggling like", error);
+        }
+    };
 
-  const handleCommentSubmit = async (e) => {
-    e.preventDefault();
-    if (!currentUser) {
-      alert("로그인 후 댓글을 작성할 수 있습니다.");
-      return;
+    if (!link) {
+        return <div className="p-4 text-center">Loading...</div>;
     }
-    if (commentText.trim()) {
-      try {
-        await addComment({ linkId, text: commentText });
-        setCommentText("");
-        const commentResponse = await getComments(linkId);
-        setComments(commentResponse.data || []);
-      } catch (err) {
-        alert("댓글 작성에 실패했습니다.");
-      }
-    }
-  };
 
-  if (loading) return <div className="text-center p-4">로딩 중...</div>;
-  if (error) return <div className="text-center p-4 text-red-600">{error}</div>;
-  if (!link)
     return (
-      <div className="text-center text-gray-600">링크를 찾을 수 없습니다.</div>
-    );
-
-  return (
-    <div className="max-w-3xl mx-auto">
-      <Link
-        to={`/category/${category}`}
-        className="text-blue-600 hover:underline mb-4 inline-block"
-      >
-        ← {category}로 돌아가기
-      </Link>
-      <div className="bg-white p-6 rounded-lg shadow-md">
-        <h1 className="text-2xl font-bold text-gray-900 mb-4">{link.title}</h1>
-        <a
-          href={link.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-blue-600 hover:underline"
-        >
-          {link.url}
-        </a>
-        <p className="text-gray-600 mt-2 mb-4">{link.description}</p>
-        <div className="flex items-center justify-between mb-4">
-          <button
-            onClick={handleLike}
-            className="flex items-center text-red-500 hover:text-red-600"
-          >
-            <svg
-              className="w-5 h-5 mr-1"
-              fill={
-                link.likedBy.includes(currentUser) ? "currentColor" : "none"
-              }
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
-              />
-            </svg>
-            {link.likes}
-          </button>
-          <span className="text-gray-500">조회수: {link.views}</span>
-        </div>
-      </div>
-      <div className="mt-8">
-        <h2 className="text-xl font-bold text-gray-900 mb-4">댓글</h2>
-        {currentUser ? (
-          <form onSubmit={handleCommentSubmit} className="mb-4">
-            <textarea
-              placeholder="댓글을 입력하세요..."
-              value={commentText}
-              onChange={(e) => setCommentText(e.target.value)}
-              className="w-full p-2 border rounded mb-2"
-              rows="4"
-            ></textarea>
-            <button
-              type="submit"
-              className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
-            >
-              댓글 작성
-            </button>
-          </form>
-        ) : (
-          <p className="text-gray-600 mb-4">
-            댓글을 작성하려면{" "}
-            <Link to="/login" className="text-blue-600 hover:underline">
-              로그인
-            </Link>
-            하세요.
-          </p>
-        )}
-        <div className="space-y-4">
-          {comments.length > 0 ? (
-            comments.map((comment) => (
-              <div key={comment.id} className="bg-gray-100 p-4 rounded-lg">
-                <div className="flex justify-between items-center mb-2">
-                  <span className="font-semibold text-gray-800">
-                    {comment.user}
-                  </span>
-                  <span className="text-gray-500 text-sm">
-                    {new Date(comment.createdAt).toLocaleString()}
-                  </span>
+        <div className="p-4">
+            <div className="bg-white shadow-lg rounded-lg p-4">
+                <h1 className="text-2xl font-bold mb-2">{link.title}</h1>
+                <p className="text-gray-700 text-sm mb-3">{link.description}</p>
+                <a
+                    href={link.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline break-all text-sm"
+                >
+                    {link.url}
+                </a>
+                <div className="flex justify-between items-center text-gray-500 mt-4 text-xs">
+                    <span>Views: {link.viewCount}</span>
+                    <button
+                        onClick={handleLike}
+                        className="px-3 py-1.5 border border-blue-600 text-blue-600 rounded-full hover:bg-blue-600 hover:text-white transition"
+                    >
+                        Like ({link.likeCount})
+                    </button>
                 </div>
-                <p className="text-gray-600">{comment.text}</p>
-              </div>
-            ))
-          ) : (
-            <p className="text-gray-600">아직 댓글이 없습니다.</p>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-};
+            </div>
 
-export default LinkDetailPage;
+            <div className="mt-6">
+                <h2 className="text-xl font-bold mb-3">Comments</h2>
+                <form onSubmit={handleAddComment} className="bg-white shadow-lg rounded-lg p-4 mb-4">
+                    <textarea
+                        className="w-full p-2 border rounded text-sm"
+                        rows="3"
+                        placeholder="Add a comment..."
+                        value={newComment}
+                        onChange={(e) => setNewComment(e.target.value)}
+                    ></textarea>
+                    <button
+                        type="submit"
+                        className="mt-2 w-full px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+                    >
+                        Submit
+                    </button>
+                </form>
+
+                <div className="space-y-3">
+                    {comments.length > 0 ? (
+                        comments.map((comment) => (
+                            <div key={comment.id} className="bg-white shadow-lg rounded-lg p-3">
+                                <p className="text-sm">{comment.content}</p>
+                            </div>
+                        ))
+                    ) : (
+                        <p className="text-sm text-gray-500">No comments yet.</p>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default MobileLinkDetailPage;

--- a/Open-Bookmarks-front/src/components/mobile/LinkDetailPage.js.bak
+++ b/Open-Bookmarks-front/src/components/mobile/LinkDetailPage.js.bak
@@ -1,0 +1,181 @@
+import React, { useState, useEffect } from "react";
+import { useParams, Link } from "react-router-dom";
+import {
+  getComments,
+  addComment,
+  incrementView,
+  toggleLike,
+} from "../../services/api";
+
+const LinkDetailPage = ({ links, currentUser }) => {
+  const { linkId } = useParams();
+  const [link, setLink] = useState(null);
+  const [comments, setComments] = useState([]);
+  const [commentText, setCommentText] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const category = Object.keys(links).find((cat) =>
+    links[cat].some((l) => l.id === linkId)
+  );
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        // 링크는 App.js에서 제공된 links 사용
+        const foundLink = Object.values(links)
+          .flat()
+          .find((l) => l.id === linkId);
+        if (!foundLink) throw new Error("링크를 찾을 수 없습니다.");
+        setLink(foundLink);
+
+        // 조회수 증가
+        await incrementView(linkId);
+
+        // 댓글 가져오기
+        const commentResponse = await getComments(linkId);
+        setComments(commentResponse.data || []);
+        setLoading(false);
+      } catch (err) {
+        setError(err.message || "데이터를 불러오는데 실패했습니다.");
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [linkId, links]);
+
+  const handleLike = async () => {
+    if (!currentUser) {
+      alert("로그인 후 좋아요를 누를 수 있습니다.");
+      return;
+    }
+    try {
+      await toggleLike(linkId);
+      // 백엔드에서 업데이트된 링크 상태를 반영하도록 리프레시
+    } catch (err) {
+      alert("좋아요 처리에 실패했습니다.");
+    }
+  };
+
+  const handleCommentSubmit = async (e) => {
+    e.preventDefault();
+    if (!currentUser) {
+      alert("로그인 후 댓글을 작성할 수 있습니다.");
+      return;
+    }
+    if (commentText.trim()) {
+      try {
+        await addComment({ linkId, text: commentText });
+        setCommentText("");
+        const commentResponse = await getComments(linkId);
+        setComments(commentResponse.data || []);
+      } catch (err) {
+        alert("댓글 작성에 실패했습니다.");
+      }
+    }
+  };
+
+  if (loading) return <div className="text-center p-4">로딩 중...</div>;
+  if (error) return <div className="text-center p-4 text-red-600">{error}</div>;
+  if (!link)
+    return (
+      <div className="text-center text-gray-600">링크를 찾을 수 없습니다.</div>
+    );
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <Link
+        to={`/category/${category}`}
+        className="text-blue-600 hover:underline mb-4 inline-block"
+      >
+        ← {category}로 돌아가기
+      </Link>
+      <div className="bg-white p-6 rounded-lg shadow-md">
+        <h1 className="text-2xl font-bold text-gray-900 mb-4">{link.title}</h1>
+        <a
+          href={link.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 hover:underline"
+        >
+          {link.url}
+        </a>
+        <p className="text-gray-600 mt-2 mb-4">{link.description}</p>
+        <div className="flex items-center justify-between mb-4">
+          <button
+            onClick={handleLike}
+            className="flex items-center text-red-500 hover:text-red-600"
+          >
+            <svg
+              className="w-5 h-5 mr-1"
+              fill={
+                link.likedBy.includes(currentUser) ? "currentColor" : "none"
+              }
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+              />
+            </svg>
+            {link.likes}
+          </button>
+          <span className="text-gray-500">조회수: {link.views}</span>
+        </div>
+      </div>
+      <div className="mt-8">
+        <h2 className="text-xl font-bold text-gray-900 mb-4">댓글</h2>
+        {currentUser ? (
+          <form onSubmit={handleCommentSubmit} className="mb-4">
+            <textarea
+              placeholder="댓글을 입력하세요..."
+              value={commentText}
+              onChange={(e) => setCommentText(e.target.value)}
+              className="w-full p-2 border rounded mb-2"
+              rows="4"
+            ></textarea>
+            <button
+              type="submit"
+              className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+            >
+              댓글 작성
+            </button>
+          </form>
+        ) : (
+          <p className="text-gray-600 mb-4">
+            댓글을 작성하려면{" "}
+            <Link to="/login" className="text-blue-600 hover:underline">
+              로그인
+            </Link>
+            하세요.
+          </p>
+        )}
+        <div className="space-y-4">
+          {comments.length > 0 ? (
+            comments.map((comment) => (
+              <div key={comment.id} className="bg-gray-100 p-4 rounded-lg">
+                <div className="flex justify-between items-center mb-2">
+                  <span className="font-semibold text-gray-800">
+                    {comment.user}
+                  </span>
+                  <span className="text-gray-500 text-sm">
+                    {new Date(comment.createdAt).toLocaleString()}
+                  </span>
+                </div>
+                <p className="text-gray-600">{comment.text}</p>
+              </div>
+            ))
+          ) : (
+            <p className="text-gray-600">아직 댓글이 없습니다.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LinkDetailPage;

--- a/Open-Bookmarks-front/src/hooks/useLinkDetail.js
+++ b/Open-Bookmarks-front/src/hooks/useLinkDetail.js
@@ -1,0 +1,88 @@
+// LinkDetailPage에서 링크 상세 정보와 댓글을 관리하는 커스텀 훅 - PC와 모바일 컴포넌트에서 동일한 로직을 공유하도록 리팩토링
+
+import { useState, useEffect, useCallback } from 'react';
+import { useParams } from 'react-router-dom';
+import * as api from '../services/api';
+
+    /*
+    LinkDetailPage에서 사용되는 모든 데이터와 로직을 관리하는 커스텀 훅
+    이 훅은 PC와 모바일 컴포넌트를 동일한 로직을 공유하도록 하고 UI 렌더링에 집중할 수 있도록 하는 근간이 됩니다.
+    */
+export function useLinkDetail() {
+  const { linkId } = useParams(); // URL로부터 linkId를 가져옴
+  const [link, setLink] = useState(null);
+  const [comments, setComments] = useState([]);
+  const [newComment, setNewComment] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // 서버로부터 링크 상세 데이터와 댓글 목록을 가져오는 함수
+  // useCallback으로 묶어 linkId가 변경될 때만 함수가 재생성되도록 최적화
+  const fetchData = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      // 링크 상세 정보와 댓글 목록을 동시에 요청
+      const [linkData, commentsData] = await Promise.all([
+        api.getLinkById(linkId),
+        api.getComments(linkId),
+      ]);
+      setLink(linkData);
+      setComments(commentsData);
+      setError(null); // 이전 에러가 있었다면 초기화
+    } catch (err) {
+      console.error('Failed to fetch link details or comments:', err);
+      setError('데이터를 불러오는 중 오류가 발생했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [linkId]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // 댓글 추가(현재는 댓글 기능 자체에 약간에 오류가 있는 것 같음)
+  const handleAddComment = async (e) => {
+    e.preventDefault();
+    if (!newComment.trim()) {
+      alert('댓글 내용을 입력해주세요.');
+      return;
+    }
+    try {
+      // API를 호출하여 서버에 댓글을 추가
+      const addedComment = await api.addComment(linkId, { content: newComment });
+      // 상태를 업데이트하여 화면에 즉시 반영
+      setComments((prevComments) => [...prevComments, addedComment]);
+      setNewComment(''); // 입력창 초기화
+    } catch (err) {
+      console.error('Failed to add comment:', err);
+      alert('댓글 작성에 실패했습니다.');
+    }
+  };
+
+  // 좋아요 하트 토글을 처리하는 함수
+  const handleLike = async () => {
+    if (!link) return;
+    try {
+      // API를 호출하여 좋아요 상태를 변경
+      const updatedLink = await api.toggleLike(linkId);
+      // 상태를 업데이트하여 화면에 즉시 반영
+      setLink(updatedLink);
+    } catch (err) {
+      console.error('Failed to toggle like:', err);
+      alert('좋아요 처리에 실패했습니다.');
+    }
+  };
+
+  // 컴포넌트에서 사용할 상태와 함수들을 객체 형태로 반환(필수)
+  return {
+    link,
+    comments,
+    newComment,
+    isLoading,
+    error,
+    setNewComment,
+    handleAddComment,
+    handleLike,
+  };
+}

--- a/Open-Bookmarks-front/src/services/api.js
+++ b/Open-Bookmarks-front/src/services/api.js
@@ -39,8 +39,8 @@ export const addLink = (link) => api.post('/links', link);
 export const toggleLike = (linkId) => api.post(`/likes/toggle/${linkId}`);
 export const incrementView = (linkId) => api.post(`/views/increment/${linkId}`);
 
-export const getComments = (linkId) => api.get(`/comments/${linkId}`);
-export const addComment = (comment) => api.post('/comments', comment);
+export const getComments = (linkId) => api.get(`/links/${linkId}/comments`);
+export const addComment = (linkId, comment) => api.post(`/links/${linkId}/comments`, comment);
 export const getUserProfile = () => api.get('/users/me');
 
 export const login = (credentials) => api.post('/users/login', credentials);


### PR DESCRIPTION
데스크톱과 모바일의 각 LinkDetailPage에 데이터 관리 로직이 중복되어 있어, 두 로직을 커스텀 훅으로 분리-통합하여 코드의 유지 보수를 용이하도록 조정하였습니다.

1. src/hooks/useLinkDetail.js 커스텀 훅 신규 생성

기존에 각 `LinkDetailPage` 컴포넌트에 흩어져 있던 데이터 조회(fetching), 상태 관리(state), 이벤트 핸들러를 `useLinkDetail` 훅으로 통합했습니다.

2. 모바일과 데스크톱의 각 LinkDetailPage 컴포넌트 리팩토링
데스크톱과 모바일 `LinkDetailPage`가 위에서 만든 `useLinkDetail` 훅을 사용하도록 수정했습니다. 각 컴포넌트에서 복잡한 로직을 제거하고, UI 렌더링에만 집중하도록 코드를 간소화했습니다.

추가로, api 호출에서 댓글 부분을 약간 조정하여 클릭 후 작동이 되도록 고쳤습니다.

새로 생성된 `useLinkDetail` 훅의 로직이 적절한지, `LinkDetailPage` 컴포넌트가 훅을 통해 데이터를 잘 받아오고, 기존과 동일하게 기능이 동작하는지 확인 부탁드립니다.

감사합니다.